### PR TITLE
Added level column to masternode tabs

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -951,19 +951,21 @@ CAmount CMasternode::CheckOutPointValue(const COutPoint& outpoint)
 
 int CMasternode::RetrieveMNType()
 {
-    int mnType = 0;
     CAmount nOutPointValue = CheckOutPointValue(vin.prevout);
     for(int i=0; i<Params().CollateralLevels(); i++) {
-        if((nOutPointValue * COIN) == (Params().ValidCollateralAmounts()[i] * COIN)) {
+        if(nOutPointValue == (Params().ValidCollateralAmounts()[i] * COIN)) {
            LogPrintf("RetrieveMNType() - masternode.cpp L958\n");
            LogPrintf("nOutPointValue == %llu\n", nOutPointValue);
            LogPrintf("Collat         == %llu\n", Params().ValidCollateralAmounts()[i]);
-           LogPrintf("mnType         == %d\n", mnType);
-           return mnType;
-	}
+           LogPrintf("mnType         == %d\n", i);
+           
+           // 0: small, 1: medium, 2: large
+           return i; 
+	    }
     }
-    LogPrintf("Exiting RetrieveMNType() via fallthrough... (! mnType %d)\n", mnType);
-    return(Params().CollateralLevels());
+
+    LogPrintf("Exiting RetrieveMNType() via fallthrough...");
+    return -1;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -112,7 +112,7 @@ struct masternode_info_t
     int nProtocolVersion = 0;
     int64_t sigTime = 0; //mnb message time
 
-    CTxIn vin{};
+    CTxIn vin{}; 
     CService addr{};
     CPubKey pubKeyCollateralAddress{};
     CPubKey pubKeyMasternode{};
@@ -242,6 +242,17 @@ public:
                 nActiveStateIn == MASTERNODE_PRE_ENABLED ||
                 nActiveStateIn == MASTERNODE_EXPIRED ||
                 nActiveStateIn == MASTERNODE_WATCHDOG_EXPIRED;
+    }
+
+    static std::string GetMNLevelStr(int level)
+    {
+        switch(level)
+        {
+            case 0:  return "3";
+            case 1:  return "2";
+            case 2:  return "1";
+            default: return  "-";
+        }
     }
 
     bool IsValidForPayment() const;

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -246,15 +246,8 @@ public:
 
     static std::string GetMNLevelStr(int level)
     {
-        switch(level)
-        {
-            default: return  "-";
-
-            // 1 based level string for user facing visualisations
-            case 0:  return "1";
-            case 1:  return "2";
-            case 2:  return "3";
-        }
+        // 1 based level string for user facing visualisations
+        return (level < 0) ? "-" : std::to_string(level + 1);
     }
 
     bool IsValidForPayment() const;

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -248,10 +248,12 @@ public:
     {
         switch(level)
         {
-            case 0:  return "3";
-            case 1:  return "2";
-            case 2:  return "1";
             default: return  "-";
+
+            // 1 based level string for user facing visualisations
+            case 0:  return "1";
+            case 1:  return "2";
+            case 2:  return "3";
         }
     }
 

--- a/src/qt/forms/masternodelist.ui
+++ b/src/qt/forms/masternodelist.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>723</width>
+    <width>743</width>
     <height>457</height>
    </rect>
   </property>
@@ -67,7 +67,7 @@
              <item>
               <widget class="QLabel" name="updateNote">
                <property name="text">
-                <string>Note: Status of your masternodes in local wallet can potentially be slightly incorrect.&lt;br /&gt;Always wait for wallet to sync additional data and then double check from another node&lt;br /&gt;if your masternode should be running but you still do not see "ENABLED" in "Status" field.</string>
+                <string>Note: Status of your masternodes in local wallet can potentially be slightly incorrect.&lt;br /&gt;Always wait for wallet to sync additional data and then double check from another node&lt;br /&gt;if your masternode should be running but you still do not see &quot;ENABLED&quot; in &quot;Status&quot; field.</string>
                </property>
               </widget>
              </item>
@@ -99,12 +99,6 @@
              <attribute name="horizontalHeaderStretchLastSection">
               <bool>true</bool>
              </attribute>
-             <attribute name="ResizeMode">
-              <enum>QHeaderView::Interactive</enum>
-             </attribute>
-             <attribute name="ResizeMode">
-              <enum>QHeaderView::Interactive</enum>
-             </attribute>
              <column>
               <property name="text">
                <string>Alias</string>
@@ -113,6 +107,14 @@
              <column>
               <property name="text">
                <string>Address</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Level</string>
+              </property>
+              <property name="textAlignment">
+               <set>AlignCenter</set>
               </property>
              </column>
              <column>
@@ -230,15 +232,17 @@
            <attribute name="horizontalHeaderStretchLastSection">
             <bool>true</bool>
            </attribute>
-           <attribute name="ResizeMode">
-            <enum>QHeaderView::Interactive</enum>
-           </attribute>
-           <attribute name="ResizeMode">
-            <enum>QHeaderView::Interactive</enum>
-           </attribute>
            <column>
             <property name="text">
              <string>Address</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Level</string>
+            </property>
+            <property name="textAlignment">
+             <set>AlignCenter</set>
             </property>
            </column>
            <column>


### PR DESCRIPTION
Added `level` column to `My Masternodes` tab
Added `level` column to `All Masternodes` tab
Centered `level` and `protocol` columns
Added helper method to retrieve the masternode level
Fixed logic in `RetrieveMNType` to return the correct level